### PR TITLE
Fix navigation link styling on landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Florel Fiskeri – Choose Language / Vælg Sprog / Sprache wählen</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link href="https://fonts.googleapis.com/css?family=Inter:400,700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css?family=Inter:400,700&amp;display=swap" rel="stylesheet" />
     <style>
       html { font-family: 'Inter', sans-serif; }
     </style>
@@ -18,9 +18,24 @@
         <p class="text-lg md:text-xl text-center mb-4">Holiday home in Danish nature – choose your language</p>
       </div>
       <nav class="flex flex-col gap-5 items-center w-full max-w-xs">
-        <a href="index-da.html" class="block w-full py-3 px-6 text-xl font-semibold rounded-lg shadow bg-[#29543c] text-white hover:bg-[#407d5e] transition text-center">Dansk</a>
-        <a href="index-en.html" class="block w-full py-3 px-6 text-xl font-semibold rounded-lg shadow bg-[#29543c] text-white hover:bg-[#407d5e] transition text-center">English</a>
-        <a href="index-de.html" class="block w-full py-3 px-6 text-xl font-semibold rounded-lg shadow bg-[#29543c] text-white hover:bg-[#407d5e] transition text-center">Deutsch</a>
+        <a
+          href="index-da.html"
+          class="block w-full py-3 px-6 text-xl font-semibold rounded-lg shadow bg-[#29543c] text-white hover:bg-[#407d5e] transition text-center"
+        >
+          Dansk
+        </a>
+        <a
+          href="index-en.html"
+          class="block w-full py-3 px-6 text-xl font-semibold rounded-lg shadow bg-[#29543c] text-white hover:bg-[#407d5e] transition text-center"
+        >
+          English
+        </a>
+        <a
+          href="index-de.html"
+          class="block w-full py-3 px-6 text-xl font-semibold rounded-lg shadow bg-[#29543c] text-white hover:bg-[#407d5e] transition text-center"
+        >
+          Deutsch
+        </a>
       </nav>
       <footer class="mt-20 text-sm text-gray-500 text-center w-full">
         © 2025 Florel Fiskeri · florelfiskeri.rf.gd


### PR DESCRIPTION
## Summary
- repair broken `text-white` classes in language navigation on main page
- escape ampersand in Google Fonts link to satisfy HTML validator

## Testing
- `tidy -e index.html`

------
https://chatgpt.com/codex/tasks/task_e_6893c63cbd5c833092b1b3b6b86c8ce8